### PR TITLE
Refactor agenda modals to match responsive mockup

### DIFF
--- a/assets/css/unified-modals.css
+++ b/assets/css/unified-modals.css
@@ -28,6 +28,19 @@
     --border-radius-lg: 12px;
     --transition-base: 0.2s ease;
     --transition-modal: 0.3s ease;
+    --agenda-modal-primary: #6D28D9;
+    --agenda-modal-primary-light: #EDE9FE;
+    --agenda-modal-secondary: #10B981;
+    --agenda-modal-danger: #EF4444;
+    --agenda-modal-gray-50: #F9FAFB;
+    --agenda-modal-gray-100: #F3F4F6;
+    --agenda-modal-gray-150: #EEF2FF;
+    --agenda-modal-gray-200: #E5E7EB;
+    --agenda-modal-gray-300: #D1D5DB;
+    --agenda-modal-gray-400: #9CA3AF;
+    --agenda-modal-gray-500: #6B7280;
+    --agenda-modal-gray-700: #374151;
+    --agenda-modal-gray-800: #1F2937;
 }
 
 /* ====================================================================
@@ -507,4 +520,768 @@
         transform: scale(0.95); 
         opacity: 0;
     }
+}
+/* ====================================================================
+   Modales responsive del módulo de agenda
+   ==================================================================== */
+
+.agenda-modal {
+    align-items: flex-end;
+    padding: 0;
+}
+
+.agenda-modal .modal-content {
+    width: 100%;
+    max-width: none;
+    border-radius: 24px 24px 0 0;
+    box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.18);
+    transform: translateY(100%);
+    transition: transform var(--transition-modal);
+    max-height: 90vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+.agenda-modal .modal-content.show {
+    transform: translateY(0);
+}
+
+@media (min-width: 768px) {
+    .agenda-modal {
+        align-items: center;
+        padding: 2rem;
+    }
+
+    .agenda-modal .modal-content {
+        border-radius: 24px;
+        max-width: 720px;
+        transform: scale(0.96);
+        box-shadow: var(--shadow-modal);
+    }
+
+    .agenda-modal .modal-content.modal-small {
+        max-width: 520px;
+    }
+
+    .agenda-modal .modal-content.modal-large {
+        max-width: 880px;
+    }
+
+    .agenda-modal .modal-content.show {
+        transform: scale(1);
+    }
+}
+
+.agenda-modal .modal-handle {
+    width: 48px;
+    height: 4px;
+    border-radius: 999px;
+    background-color: var(--agenda-modal-gray-300);
+    margin: 0.75rem auto 0.25rem;
+}
+
+@media (min-width: 768px) {
+    .agenda-modal .modal-handle {
+        display: none;
+    }
+}
+
+.agenda-modal .modal-header {
+    padding: 1.5rem 1.5rem 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.agenda-modal .modal-title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--agenda-modal-gray-800);
+}
+
+.agenda-modal .modal-subtitle {
+    margin: 0.35rem 0 0;
+    color: var(--agenda-modal-gray-500);
+    font-size: 0.95rem;
+}
+
+.agenda-modal .modal-close-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: none;
+    background: var(--agenda-modal-gray-100);
+    color: var(--agenda-modal-gray-500);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background var(--transition-base), color var(--transition-base);
+}
+
+.agenda-modal .modal-close-btn:hover {
+    background: var(--agenda-modal-gray-200);
+    color: var(--agenda-modal-gray-700);
+}
+
+.agenda-modal .modal-body {
+    padding: 0 1.5rem 1.75rem;
+    overflow-y: auto;
+}
+
+.agenda-modal .modal-footer {
+    padding: 1.25rem 1.5rem 1.5rem;
+    border-top: 1px solid var(--agenda-modal-gray-200);
+    background: var(--agenda-modal-gray-50);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+    .agenda-modal .modal-footer {
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: center;
+    }
+}
+
+.agenda-modal .btn {
+    border-radius: 0.85rem;
+    font-weight: 600;
+    padding: 0.75rem 1.25rem;
+    width: 100%;
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+@media (min-width: 640px) {
+    .agenda-modal .btn {
+        width: auto;
+    }
+}
+
+.agenda-modal .btn-primary {
+    background: var(--agenda-modal-primary);
+    color: #fff;
+}
+
+.agenda-modal .btn-primary:hover {
+    background: #5b21b6;
+    box-shadow: 0 10px 20px rgba(109, 40, 217, 0.25);
+}
+
+.agenda-modal .btn-primary:disabled {
+    background: rgba(109, 40, 217, 0.45);
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.agenda-modal .btn-secondary {
+    background: var(--agenda-modal-secondary);
+    color: #fff;
+}
+
+.agenda-modal .btn-secondary:hover {
+    background: #059669;
+}
+
+.agenda-modal .btn-light {
+    background: var(--agenda-modal-gray-100);
+    color: var(--agenda-modal-gray-700);
+}
+
+.agenda-modal .btn-light:hover {
+    background: var(--agenda-modal-gray-200);
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    background: var(--agenda-modal-gray-100);
+    color: var(--agenda-modal-gray-700);
+}
+
+.status-pill-indicator {
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.65);
+}
+
+.status-pill--confirmed {
+    background: #D1FAE5;
+    color: #047857;
+}
+
+.status-pill--completed {
+    background: #DBEAFE;
+    color: #1D4ED8;
+}
+
+.status-pill--pending {
+    background: var(--agenda-modal-primary-light);
+    color: var(--agenda-modal-primary);
+}
+
+.status-pill--cancelled {
+    background: #FEE2E2;
+    color: #B91C1C;
+}
+
+.appointment-details-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+@media (min-width: 768px) {
+    .appointment-details-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1.25rem;
+    }
+}
+
+.info-card {
+    background: #fff;
+    border: 1px solid var(--agenda-modal-gray-200);
+    border-radius: 1.25rem;
+    padding: 1.25rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+}
+
+.info-card-header {
+    margin: 0 0 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--agenda-modal-gray-500);
+}
+
+.info-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.info-card-row {
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+    color: var(--agenda-modal-gray-700);
+    font-size: 0.95rem;
+}
+
+.info-card-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: var(--agenda-modal-primary-light);
+    color: var(--agenda-modal-primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+}
+
+.info-card-data.strong {
+    font-weight: 700;
+    color: var(--agenda-modal-gray-800);
+}
+
+.info-card-note {
+    margin: 0;
+    color: var(--agenda-modal-gray-600);
+    line-height: 1.5;
+}
+
+.info-card-note.muted {
+    color: var(--agenda-modal-gray-400);
+    text-align: center;
+}
+
+.status-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+}
+
+@media (min-width: 640px) {
+    .status-actions {
+        flex-direction: row;
+        justify-content: flex-end;
+    }
+}
+
+.status-actions .status-btn {
+    flex: 1;
+    min-width: 160px;
+    border: none;
+    border-radius: 0.9rem;
+    padding: 0.75rem 1.25rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.status-actions .status-btn.confirmed {
+    background: var(--agenda-modal-secondary);
+    color: #fff;
+}
+
+.status-actions .status-btn.completed {
+    background: var(--agenda-modal-primary);
+    color: #fff;
+}
+
+.status-actions .status-btn.cancelled {
+    background: var(--agenda-modal-danger);
+    color: #fff;
+}
+
+.status-actions .status-btn.disabled,
+.status-actions .status-btn:disabled {
+    background: var(--agenda-modal-gray-200);
+    color: var(--agenda-modal-gray-500);
+    cursor: not-allowed;
+    box-shadow: none;
+    pointer-events: none;
+}
+
+.status-actions .status-btn:not(.disabled):not(:disabled):hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 22px rgba(15, 23, 42, 0.15);
+}
+
+.appointment-modal__footer .form-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+}
+
+@media (min-width: 640px) {
+    .appointment-modal__footer .form-actions {
+        flex-direction: row;
+        justify-content: flex-end;
+    }
+}
+
+/* Wizard */
+
+.agenda-wizard .wizard-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding-bottom: 1.5rem;
+}
+
+.agenda-wizard .progress-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.agenda-wizard .progress-step {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--agenda-modal-gray-400);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.agenda-wizard .progress-step-number {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    border: 2px solid var(--agenda-modal-gray-200);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    transition: all var(--transition-modal);
+}
+
+.agenda-wizard .progress-step.active .progress-step-number {
+    border-color: var(--agenda-modal-primary);
+    background: var(--agenda-modal-primary);
+    color: #fff;
+    box-shadow: 0 12px 25px rgba(109, 40, 217, 0.25);
+}
+
+.agenda-wizard .progress-step.active .progress-step-label {
+    color: var(--agenda-modal-gray-800);
+}
+
+.agenda-wizard .progress-bar-divider {
+    flex: 1;
+    border-top: 2px dashed var(--agenda-modal-gray-200);
+}
+
+@media (max-width: 767px) {
+    .agenda-wizard .progress-step-label {
+        display: none;
+    }
+}
+
+.wizard-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.wizard-step {
+    display: none;
+    background: var(--agenda-modal-gray-50);
+    border: 1px solid var(--agenda-modal-gray-200);
+    border-radius: 1.25rem;
+    padding: 1.5rem;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.06);
+}
+
+.wizard-step.active {
+    display: block;
+    animation: wizardFadeIn 0.3s ease;
+}
+
+@keyframes wizardFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.wizard-step-header {
+    margin-bottom: 1.25rem;
+}
+
+.wizard-step-title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--agenda-modal-gray-800);
+}
+
+.wizard-step-subtitle {
+    margin: 0.35rem 0 0;
+    color: var(--agenda-modal-gray-500);
+    font-size: 0.95rem;
+}
+
+.wizard-step-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.wizard-step-footer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+@media (min-width: 640px) {
+    .wizard-step-footer {
+        flex-direction: row;
+        justify-content: flex-end;
+    }
+}
+
+.wizard-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.wizard-form-intro {
+    margin: 0;
+    color: var(--agenda-modal-gray-500);
+    font-size: 0.95rem;
+}
+
+.input-with-icon {
+    position: relative;
+}
+
+.input-with-icon i {
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--agenda-modal-gray-400);
+    pointer-events: none;
+}
+
+.input-with-icon .form-input {
+    padding-left: 2.75rem;
+}
+
+.search-results-card {
+    border: 1px solid var(--agenda-modal-gray-200);
+    border-radius: 1rem;
+    background: var(--agenda-modal-gray-50);
+    padding: 1rem;
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.search-placeholder {
+    margin: 0;
+    color: var(--agenda-modal-gray-500);
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+.result-item {
+    background: #fff;
+    border: 1px solid transparent;
+    border-radius: 0.9rem;
+    padding: 0.85rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    cursor: pointer;
+    transition: border var(--transition-base), box-shadow var(--transition-base);
+}
+
+.result-item + .result-item {
+    margin-top: 0.75rem;
+}
+
+.result-item:hover {
+    border-color: var(--agenda-modal-primary);
+    box-shadow: 0 12px 26px rgba(109, 40, 217, 0.22);
+}
+
+.result-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.result-item-tag {
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.result-item-tag.tag-mine {
+    background: var(--agenda-modal-secondary);
+    color: #fff;
+}
+
+.result-item-tag.tag-network {
+    background: var(--agenda-modal-gray-200);
+    color: var(--agenda-modal-gray-700);
+}
+
+.info-banner {
+    background: var(--agenda-modal-primary-light);
+    color: var(--agenda-modal-primary);
+    padding: 0.85rem 1.1rem;
+    border-radius: 0.85rem;
+    font-weight: 600;
+}
+
+.pet-selection-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pet-selection-list .pet-item {
+    background: #fff;
+    border: 1px solid var(--agenda-modal-gray-200);
+    border-radius: 1rem;
+    padding: 1rem 1.1rem;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pet-item-main {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.pet-item-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    background: var(--agenda-modal-primary-light);
+    color: var(--agenda-modal-primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+}
+
+.pet-item-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.pet-item-name {
+    font-weight: 700;
+    color: var(--agenda-modal-gray-800);
+}
+
+.pet-item-meta {
+    font-size: 0.85rem;
+    color: var(--agenda-modal-gray-500);
+}
+
+.pet-selection-list .pet-item.locked .pet-item-main {
+    opacity: 0.75;
+}
+
+.pet-selection-list .pet-item .fa-chevron-right {
+    color: var(--agenda-modal-gray-300);
+}
+
+.pet-selection-list .pet-item.selectable {
+    cursor: pointer;
+    transition: border var(--transition-base), box-shadow var(--transition-base);
+}
+
+.pet-selection-list .pet-item.selectable:hover {
+    border-color: var(--agenda-modal-primary);
+    box-shadow: 0 18px 30px rgba(109, 40, 217, 0.2);
+}
+
+.pet-selection-list .pet-item.selected {
+    border-color: var(--agenda-modal-primary);
+    background: var(--agenda-modal-primary-light);
+}
+
+.pet-selection-list .pet-item.locked {
+    opacity: 0.8;
+}
+
+.pet-selection-list .unlock-section {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+@media (max-width: 600px) {
+    .pet-selection-list .unlock-section {
+        flex-direction: column;
+    }
+}
+
+.wizard-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+    .wizard-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.slot-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.slot-list {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.5rem;
+    border: 1px solid var(--agenda-modal-gray-200);
+    border-radius: 1rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    background: #fff;
+}
+
+.slot-list::-webkit-scrollbar {
+    display: none;
+}
+
+.slot-list {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+.time-slot {
+    min-width: 120px;
+    padding: 0.75rem 1rem;
+    border-radius: 0.9rem;
+    border: 1px solid var(--agenda-modal-gray-200);
+    background: #fff;
+    font-weight: 600;
+    color: var(--agenda-modal-gray-700);
+    cursor: pointer;
+    scroll-snap-align: start;
+    transition: all var(--transition-base);
+    text-align: center;
+}
+
+.time-slot:hover {
+    border-color: var(--agenda-modal-primary);
+    box-shadow: 0 12px 24px rgba(109, 40, 217, 0.18);
+}
+
+.time-slot.selected {
+    background: var(--agenda-modal-primary);
+    color: #fff;
+    border-color: var(--agenda-modal-primary);
+    box-shadow: 0 18px 32px rgba(109, 40, 217, 0.28);
+}
+
+.slots-message {
+    width: 100%;
+    text-align: center;
+    color: var(--agenda-modal-gray-500);
+    padding: 0.75rem;
+}
+
+.slot-pagination {
+    display: flex;
+    gap: 0.35rem;
+    justify-content: center;
+    margin-top: 0.25rem;
+}
+
+.slot-pagination .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--agenda-modal-gray-300);
+}
+
+.slot-pagination .dot.active {
+    background: var(--agenda-modal-primary);
 }

--- a/assets/js/modules/agenda-module.js
+++ b/assets/js/modules/agenda-module.js
@@ -229,7 +229,7 @@
         setupModalEventListeners() {
             const modal = this.container.querySelector('#appointment-modal');
             if (modal) {
-                const closeBtn = modal.querySelector('.modal-close-x');
+                const closeBtn = modal.querySelector('.modal-close-btn');
                 if (closeBtn) {
                     closeBtn.addEventListener('click', () => this.hideModal(modal));
                 }
@@ -372,10 +372,12 @@
         const modalTitle = modal.querySelector('#modal-title');
         const modalBody = modal.querySelector('#modal-details');
         const modalFooter = modal.querySelector('#status-buttons-container');
+        const statusPill = modal.querySelector('#appointment-status-pill');
 
         if (modalTitle) modalTitle.textContent = 'Registrar en Bitácora';
         if (modalBody) modalBody.innerHTML = '<div class="loading-state"><div class="loader"></div><p>Cargando formulario...</p></div>';
         if (modalFooter) modalFooter.innerHTML = '';
+        if (statusPill) statusPill.hidden = true;
 
         try {
             let service = null;
@@ -565,8 +567,33 @@
 
         const modalTitle = modal.querySelector('#modal-title');
         const modalDetails = modal.querySelector('#modal-details');
+        const statusPill = modal.querySelector('#appointment-status-pill');
+        const statusLabel = modal.querySelector('#appointment-status-label');
 
-        if (modalTitle) modalTitle.textContent = appointment.service;
+        if (modalTitle) {
+            modalTitle.textContent = appointment.service;
+        }
+
+        const statusMap = {
+            confirmed: { label: 'Confirmada', className: 'status-pill--confirmed' },
+            completed: { label: 'Completada', className: 'status-pill--completed' },
+            cancelled: { label: 'Cancelada', className: 'status-pill--cancelled' },
+            pending: { label: 'Pendiente', className: 'status-pill--pending' }
+        };
+
+        if (statusPill) {
+            const pillClasses = ['status-pill--confirmed', 'status-pill--completed', 'status-pill--cancelled', 'status-pill--pending'];
+            statusPill.classList.remove(...pillClasses);
+            const statusInfo = statusMap[appointment.status] || { label: 'Sin estado', className: '' };
+            if (statusInfo.className) {
+                statusPill.classList.add(statusInfo.className);
+            }
+            statusPill.hidden = false;
+            statusPill.setAttribute('data-status', appointment.status || 'unknown');
+            if (statusLabel) {
+                statusLabel.textContent = statusInfo.label;
+            }
+        }
 
         const appointmentDate = new Date(appointment.date + 'T12:00:00');
         const formattedDate = appointmentDate.toLocaleDateString('es-ES', {
@@ -577,37 +604,77 @@
         });
 
         if (modalDetails) {
-            modalDetails.innerHTML = `
-                <div class="appointment-details">
-                    <p><strong>Cliente:</strong> ${appointment.client}</p>
-                    <p><strong>Mascota:</strong> ${appointment.pet}</p>
-                    <p><strong>Fecha:</strong> ${formattedDate}</p>
-                    <p><strong>Hora:</strong> ${appointment.start} - ${appointment.end}</p>
-                    ${appointment.phone ? `<p><strong>Teléfono:</strong> ${appointment.phone}</p>` : ''}
-                    ${appointment.email ? `<p><strong>Email:</strong> ${appointment.email}</p>` : ''}
-                    ${appointment.description ? `<p><strong>Notas:</strong> ${appointment.description}</p>` : ''}
+            const buildInfoRows = (rows = []) => rows.map(row => `
+                <div class="info-card-row">
+                    <span class="info-card-icon"><i class="fas ${row.icon}" aria-hidden="true"></i></span>
+                    <span class="info-card-data${row.strong ? ' strong' : ''}">${row.label}</span>
                 </div>
+            `).join('');
+
+            const clientRows = [
+                { icon: 'fa-user', label: appointment.client || 'Cliente sin nombre', strong: true },
+                { icon: 'fa-paw', label: appointment.pet || 'Mascota no especificada' }
+            ];
+
+            if (appointment.phone) {
+                clientRows.push({ icon: 'fa-phone', label: appointment.phone });
+            }
+            if (appointment.email) {
+                clientRows.push({ icon: 'fa-envelope', label: appointment.email });
+            }
+
+            const serviceRows = [
+                { icon: 'fa-scissors', label: appointment.service || 'Servicio no especificado', strong: true },
+                { icon: 'fa-calendar-day', label: formattedDate },
+                { icon: 'fa-clock', label: `${appointment.start} - ${appointment.end}` }
+            ];
+
+            const notesContent = appointment.description
+                ? `<p class="info-card-note">${appointment.description}</p>`
+                : '<p class="info-card-note muted">Sin notas registradas para esta cita.</p>';
+
+            modalDetails.innerHTML = `
+                <article class="info-card">
+                    <p class="info-card-header">CLIENTE Y MASCOTA</p>
+                    <div class="info-card-body">
+                        ${buildInfoRows(clientRows)}
+                    </div>
+                </article>
+                <article class="info-card">
+                    <p class="info-card-header">SERVICIO Y HORARIO</p>
+                    <div class="info-card-body">
+                        ${buildInfoRows(serviceRows)}
+                    </div>
+                </article>
+                <article class="info-card">
+                    <p class="info-card-header">OBSERVACIONES</p>
+                    <div class="info-card-body">
+                        ${notesContent}
+                    </div>
+                </article>
             `;
         }
 
         const statusContainer = modal.querySelector('#status-buttons-container');
         if (statusContainer) {
             const statuses = [
-                { key: 'confirmed', label: 'Confirmar', class: 'confirmed' },
-                { key: 'completed', label: 'Completar', class: 'completed' },
-                { key: 'cancelled', label: 'Cancelar', class: 'cancelled' }
+                { key: 'confirmed', label: 'Confirmar', class: 'confirmed', icon: 'fa-circle-check' },
+                { key: 'completed', label: 'Completar', class: 'completed', icon: 'fa-flag-checkered' },
+                { key: 'cancelled', label: 'Cancelar', class: 'cancelled', icon: 'fa-circle-xmark' }
             ];
 
             statusContainer.innerHTML = statuses.map(statusInfo => {
                 const isCurrentStatus = appointment.status === statusInfo.key;
                 return `
                     <button
+                        type="button"
                         class="status-btn ${isCurrentStatus ? 'disabled' : statusInfo.class}"
                         data-status="${statusInfo.key}"
                         data-appointment-id="${appointment.id}"
                         ${isCurrentStatus ? 'disabled' : ''}
                     >
-                        ${statusInfo.label}
+                        <i class="fas ${statusInfo.icon}" aria-hidden="true"></i>
+                        <span>${statusInfo.label}</span>
                     </button>
                 `;
             }).join('');

--- a/assets/js/modules/agenda-wizard.js
+++ b/assets/js/modules/agenda-wizard.js
@@ -13,8 +13,7 @@ const AgendaWizard = (function ($) {
         currentClientPets: [],
         // <-- Propiedades nuevas para el agendamiento -->
         servicesAndCategories: [],
-        selectedService: { id: null, duration: null },
-        currentCalendarDate: new Date(),
+        selectedService: { id: null, duration: null, name: null },
         selectedDate: null,
         selectedSlot: null,
     };
@@ -28,14 +27,16 @@ const AgendaWizard = (function ($) {
         dom.modal = modal;
         dom.title = modal.find('#wizard-title');
         dom.steps = modal.find('.wizard-step');
+        dom.progressSteps = modal.find('.progress-step');
         dom.closeBtn = modal.find('#wizard-close-btn');
         dom.clientSearchInput = modal.find('#wizard-client-search');
         dom.searchResultsContainer = modal.find('#wizard-search-results');
-        // <-- Nuevos elementos del DOM para el Paso 3 -->
-        dom.schedulingInterface = modal.find('#wizard-scheduling-interface');
-        dom.calendarHeader = modal.find('#va-calendar-header');
-        dom.calendarGrid = modal.find('#va-calendar-grid');
-        dom.slotsContainer = modal.find('#va-slots-container');
+        dom.categorySelect = modal.find('#wiz-category');
+        dom.serviceSelect = modal.find('#wiz-service');
+        dom.dateInput = modal.find('#wiz-date');
+        dom.slotsWrapper = modal.find('#wiz-slots');
+        dom.slotsWrapperContainer = modal.find('#wiz-slots-wrapper');
+        dom.slotsPagination = modal.find('#wiz-slots-pagination');
         dom.confirmBtn = modal.find('#wizard-confirm-appointment-btn');
         console.log('🔧 DOM cacheado:', {
             modal: dom.modal.length,
@@ -74,48 +75,40 @@ const AgendaWizard = (function ($) {
         });
         
         // <-- INICIO DE NUEVOS EVENTOS: Proyecto Chocovainilla - Paso 1.5/1.6 -->
-        dom.modal.on('change', '#wizard-category-select', function() {
-            const categoryId = $(this).val();
-            const serviceSelect = dom.modal.find('#wizard-service-select');
-
-            if (categoryId) {
-                const selectedCategory = state.servicesAndCategories.find(cat => cat.category_id == categoryId);
-                if (selectedCategory && selectedCategory.services.length > 0) {
-                    let serviceOptions = '<option value="">-- Selecciona un servicio --</option>';
-                    selectedCategory.services.forEach(service => {
-                        serviceOptions += `<option value="${service.service_id}" data-duration="${service.duration}">${service.name} ($${parseFloat(service.price).toFixed(2)})</option>`;
-                    });
-                    serviceSelect.html(serviceOptions).prop('disabled', false);
-                } else {
-                    serviceSelect.html('<option value="">-- No hay servicios en esta categoría --</option>').prop('disabled', true);
-                }
-            } else {
-                serviceSelect.html('<option value="">-- Primero elige una categoría --</option>').prop('disabled', true);
-            }
+        dom.modal.on('change', '#wiz-category', function() {
+            handleCategorySelection($(this).val());
         });
 
-        dom.modal.on('change', '#wizard-service-select', function() {
+        dom.modal.on('change', '#wiz-service', function() {
             const selectedOption = $(this).find('option:selected');
             const serviceId = selectedOption.val();
             if (serviceId) {
                 const duration = selectedOption.data('duration');
-                handleServiceSelection(serviceId, duration);
+                const name = selectedOption.data('service-name') || selectedOption.text();
+                handleServiceSelection(serviceId, duration, name);
+            } else {
+                state.selectedService = { id: null, duration: null, name: null };
+                state.selectedSlot = null;
+                updateSlotsMessage('Selecciona un servicio para ver los horarios disponibles.');
+                dom.confirmBtn.prop('disabled', true);
             }
         });
 
-        dom.calendarHeader.on('click', '#prev-month-btn', () => changeMonth(-1));
-        dom.calendarHeader.on('click', '#next-month-btn', () => changeMonth(1));
-        
-        dom.calendarGrid.on('click', '.calendar-day:not(.disabled, .not-in-month)', function() {
-             dom.calendarGrid.find('.calendar-day').removeClass('selected');
-             $(this).addClass('selected');
-             state.selectedDate = $(this).data('date');
-             fetchAndRenderSlots(state.selectedDate);
+        dom.modal.on('change', '#wiz-date', function() {
+            const selectedDate = $(this).val();
+            state.selectedDate = selectedDate || null;
+            console.log('📅 Wizard: Fecha seleccionada', state.selectedDate);
+            if (state.selectedService.id && state.selectedDate) {
+                fetchAndRenderSlots(state.selectedDate);
+            } else {
+                dom.confirmBtn.prop('disabled', true);
+                updateSlotsMessage('Selecciona un servicio y fecha para ver horarios.');
+            }
         });
 
-        dom.slotsContainer.on('click', '.time-slot', function() {
+        dom.modal.on('click', '#wiz-slots .time-slot', function() {
             state.selectedSlot = $(this).data('time');
-            dom.slotsContainer.find('.time-slot').removeClass('selected');
+            dom.slotsWrapper.find('.time-slot').removeClass('selected');
             $(this).addClass('selected');
             dom.confirmBtn.prop('disabled', false);
         });
@@ -200,12 +193,14 @@ const AgendaWizard = (function ($) {
         dom.modal.removeClass('hidden');
         setTimeout(() => {
             dom.modal.addClass('visible');
+            dom.modal.find('.modal-content').addClass('show');
             console.log("   - Clases DESPUÉS de modificar:", typeof dom.modal.attr === 'function' ? dom.modal.attr('class') : dom.modal[0]?.className);
             console.log("   - Modal ahora visible.");
         }, 10);
     }
 
     function close() {
+        dom.modal.find('.modal-content').removeClass('show');
         dom.modal.removeClass('visible');
         setTimeout(() => {
             dom.modal.addClass('hidden');
@@ -219,6 +214,17 @@ const AgendaWizard = (function ($) {
         dom.steps.hide().removeClass('active');
         dom.steps.filter(`[data-step="${stepNumber}"]`).show().addClass('active');
         console.log(`🔷 Chocovainilla Wizard: Mostrando paso ${stepNumber}`);
+
+        const mainStep = Math.floor(stepNumber);
+        if (dom.progressSteps && dom.progressSteps.length) {
+            dom.progressSteps.removeClass('active');
+            dom.progressSteps.each(function() {
+                const step = parseInt($(this).data('progress-step'), 10);
+                if (step <= mainStep) {
+                    $(this).addClass('active');
+                }
+            });
+        }
 
         // Lógica específica para cada paso
         if (stepNumber === 1.5) {
@@ -252,14 +258,26 @@ const AgendaWizard = (function ($) {
         state.selectedClientEmail = null;
         state.selectedClientPhone = null;
         state.currentClientPets = [];
+        state.servicesAndCategories = [];
         state.selectedPetId = null;
-        state.selectedService = { id: null, duration: null };
-        state.selectedDate = null;
+        state.selectedService = { id: null, duration: null, name: null };
+        const today = new Date();
+        const isoToday = today.toISOString().split('T')[0];
+        state.selectedDate = isoToday;
         state.selectedSlot = null;
-        state.currentCalendarDate = new Date();
         dom.clientSearchInput.val('');
         dom.searchResultsContainer.html('<p class="text-center text-gray-500">Introduce al menos 3 caracteres para buscar.</p>');
-        dom.confirmBtn.prop('disabled', true);
+        if (dom.categorySelect && dom.categorySelect.length) {
+            dom.categorySelect.val('').prop('disabled', true);
+        }
+        if (dom.serviceSelect && dom.serviceSelect.length) {
+            dom.serviceSelect.html('<option value="">Selecciona una categoría primero</option>').prop('disabled', true);
+        }
+        if (dom.dateInput && dom.dateInput.length) {
+            dom.dateInput.attr('min', isoToday).val(isoToday);
+        }
+        updateSlotsMessage('Selecciona un servicio para ver los horarios disponibles.');
+        dom.confirmBtn.prop('disabled', true).text('Confirmar cita');
     }
 
     // --- Lógica de Búsqueda y Vinculación (sin cambios) ---
@@ -382,15 +400,22 @@ const AgendaWizard = (function ($) {
 
         const petsHtml = petsArray.map(pet => {
             const hasAccess = (typeof pet.has_access !== 'undefined') ? (parseInt(pet.has_access) === 1) : professionalAccess.includes(pet.pet_id);
+            const petName = pet && pet.name ? pet.name : `Mascota ${pet.pet_id}`;
+            const petSpecies = pet && pet.species ? pet.species : 'Especie no especificada';
             return `
                 <div class="pet-item ${hasAccess ? 'selectable' : 'locked'}" data-pet-id="${pet.pet_id}">
-                    <div>
-                        <strong>${pet.name}</strong> (${pet.species})
+                    <div class="pet-item-main">
+                        <div class="pet-item-avatar" aria-hidden="true">🐾</div>
+                        <div class="pet-item-info">
+                            <div class="pet-item-name">${petName}</div>
+                            <div class="pet-item-meta">${petSpecies}</div>
+                        </div>
+                        ${hasAccess ? '<i class="fas fa-chevron-right" aria-hidden="true"></i>' : ''}
                     </div>
                     ${!hasAccess ?
                         `<div class="unlock-section">
                             <input type="text" id="share-code-${pet.pet_id}" class="form-input" placeholder="Share-Code">
-                            <button class="btn btn-secondary unlock-btn" data-pet-id="${pet.pet_id}">Desbloquear</button>
+                            <button type="button" class="btn btn-secondary unlock-btn" data-pet-id="${pet.pet_id}">Desbloquear</button>
                         </div>` :
                         ''
                     }
@@ -440,115 +465,142 @@ const AgendaWizard = (function ($) {
         const pet = (state.currentClientPets || []).find(p => String(p.pet_id) === String(petId));
         const labelClientName = state.selectedClientName || '';
         const labelPetName = pet && pet.name ? pet.name : `Mascota ${petId}`;
-        $('#wizard-selected-pet-name').text(labelClientName ? `${labelPetName} (${labelClientName})` : `${labelPetName}`);
+        const subtitle = labelClientName ? `${labelPetName} · ${labelClientName}` : `${labelPetName}`;
+        $('#wizard-selected-pet-name').text(`Agendando para ${subtitle}`);
         showStep(3);
     }
 
     // <-- INICIO DE NUEVAS FUNCIONES: Proyecto Chocovainilla - Paso 1.5/1.6 -->
     function loadServicesAndCategories() {
-        console.log("🔄 Chocovainilla Wizard: Cargando servicios y categorías...");
-        dom.schedulingInterface.find('.service-list-content').html('<p>Cargando...</p>');
-        
+        console.log('🔄 Chocovainilla Wizard: Cargando servicios y categorías...');
+        if (dom.categorySelect && dom.categorySelect.length) {
+            dom.categorySelect.prop('disabled', true).html('<option value="">Cargando categorías...</option>');
+        }
+        if (dom.serviceSelect && dom.serviceSelect.length) {
+            dom.serviceSelect.prop('disabled', true).html('<option value="">Selecciona una categoría primero</option>');
+        }
+        updateSlotsMessage('Selecciona un servicio para ver los horarios disponibles.');
+
         $.ajax({
             url: VA_REST.api_url + `professionals/${state.professionalId}/services-and-categories`,
             beforeSend: function (xhr) { xhr.setRequestHeader('X-WP-Nonce', VA_REST.api_nonce); }
         }).done(function(response) {
             if (response.success) {
                 state.servicesAndCategories = response.data;
-                console.log("✅ Chocovainilla Wizard: Servicios cargados:", state.servicesAndCategories);
+                console.log('✅ Chocovainilla Wizard: Servicios cargados:', state.servicesAndCategories);
                 renderServicesInterface();
+            } else {
+                updateSlotsMessage('No fue posible cargar los servicios disponibles.');
             }
+        }).fail(function() {
+            updateSlotsMessage('Ocurrió un error al consultar los servicios.');
         });
     }
 
     function renderServicesInterface() {
-        if (!state.servicesAndCategories || state.servicesAndCategories.length === 0) {
-            dom.schedulingInterface.html('<p>No hay servicios configurados.</p>');
+        if (!dom.categorySelect || !dom.categorySelect.length) {
             return;
         }
 
-        const categoryOptions = state.servicesAndCategories.map(cat => `
-            <option value="${cat.category_id}">${cat.name}</option>
-        `).join('');
-
-        const dropdownsHtml = `
-            <div class="form-group">
-                <label for="wizard-category-select" class="form-label">Categoría</label>
-                <select id="wizard-category-select" class="form-input">
-                    <option value="">-- Selecciona una categoría --</option>
-                    ${categoryOptions}
-                </select>
-            </div>
-            <div class="form-group">
-                <label for="wizard-service-select" class="form-label">Servicio</label>
-                <select id="wizard-service-select" class="form-input" disabled>
-                    <option value="">-- Primero elige una categoría --</option>
-                </select>
-            </div>
-        `;
-
-        dom.modal.find('.category-tabs').html(dropdownsHtml);
-        dom.modal.find('.service-list-content').html('').hide();
-    }
-
-    function handleServiceSelection(serviceId, duration) {
-        state.selectedService = { id: serviceId, duration: duration };
-        console.log(`🔧 Chocovainilla Wizard: Servicio seleccionado ID ${serviceId}, Duración ${duration} min.`);
-        
-        dom.modal.find('.service-list-content, .category-tabs').hide();
-        dom.modal.find('.time-selection-content').show();
-        renderCalendar();
-    }
-
-    function changeMonth(direction) {
-        state.currentCalendarDate.setMonth(state.currentCalendarDate.getMonth() + direction);
-        renderCalendar();
-    }
-
-    function renderCalendar() {
-        dom.slotsContainer.html('<p class="initial-message">Selecciona una fecha para ver los horarios.</p>');
-        dom.confirmBtn.prop('disabled', true);
-        const date = state.currentCalendarDate;
-        const year = date.getFullYear();
-        const month = date.getMonth();
-        const monthNames = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
-        
-        dom.calendarHeader.html(`<button id="prev-month-btn" aria-label="Mes anterior"><i class="fas fa-chevron-left"></i></button><span id="va-calendar-month-year">${monthNames[month]} ${year}</span><button id="next-month-btn" aria-label="Mes siguiente"><i class="fas fa-chevron-right"></i></button>`);
-        
-        let gridHtml = '<div class="calendar-day-name">D</div><div class="calendar-day-name">L</div><div class="calendar-day-name">M</div><div class="calendar-day-name">M</div><div class="calendar-day-name">J</div><div class="calendar-day-name">V</div><div class="calendar-day-name">S</div>';
-        const firstDayIndex = (new Date(year, month, 1).getDay()) % 7; // Domingo = 0
-        const daysInMonth = new Date(year, month + 1, 0).getDate();
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-
-        for (let i = 0; i < firstDayIndex; i++) gridHtml += '<div class="calendar-day not-in-month"></div>';
-        for (let i = 1; i <= daysInMonth; i++) {
-            const dayDate = new Date(year, month, i);
-            let classes = 'calendar-day';
-            if (dayDate < today) classes += ' disabled';
-            const dateString = `${year}-${String(month + 1).padStart(2, '0')}-${String(i).padStart(2, '0')}`;
-            gridHtml += `<div class="${classes}" data-date="${dateString}">${i}</div>`;
+        if (!state.servicesAndCategories || state.servicesAndCategories.length === 0) {
+            dom.categorySelect.html('<option value="">No hay categorías disponibles</option>').prop('disabled', true);
+            dom.serviceSelect.html('<option value="">Sin servicios disponibles</option>').prop('disabled', true);
+            updateSlotsMessage('No hay servicios configurados para este profesional.');
+            return;
         }
-        dom.calendarGrid.html(gridHtml);
+
+        const options = ['<option value="">Selecciona una categoría</option>'];
+        state.servicesAndCategories.forEach(cat => {
+            options.push(`<option value="${cat.category_id}">${cat.name}</option>`);
+        });
+
+        dom.categorySelect.html(options.join('')).prop('disabled', false);
+        dom.serviceSelect.html('<option value="">Selecciona una categoría primero</option>').prop('disabled', true);
+    }
+
+    function handleCategorySelection(categoryId) {
+        if (!dom.serviceSelect || !dom.serviceSelect.length) return;
+
+        state.selectedService = { id: null, duration: null, name: null };
+        state.selectedSlot = null;
+        dom.confirmBtn.prop('disabled', true);
+
+        if (!categoryId) {
+            dom.serviceSelect.html('<option value="">Selecciona una categoría primero</option>').prop('disabled', true);
+            updateSlotsMessage('Selecciona un servicio para ver los horarios disponibles.');
+            return;
+        }
+
+        const selectedCategory = state.servicesAndCategories.find(cat => String(cat.category_id) === String(categoryId));
+        if (!selectedCategory || !Array.isArray(selectedCategory.services) || selectedCategory.services.length === 0) {
+            dom.serviceSelect.html('<option value="">No hay servicios en esta categoría</option>').prop('disabled', true);
+            updateSlotsMessage('No hay horarios disponibles para esta categoría.');
+            return;
+        }
+
+        const serviceOptions = ['<option value="">Selecciona un servicio</option>'];
+        selectedCategory.services.forEach(service => {
+            serviceOptions.push(`<option value="${service.service_id}" data-duration="${service.duration}" data-service-name="${service.name}">${service.name}</option>`);
+        });
+
+        dom.serviceSelect.html(serviceOptions.join('')).prop('disabled', false);
+        updateSlotsMessage('Selecciona un servicio para ver los horarios disponibles.');
+    }
+
+    function handleServiceSelection(serviceId, duration, name) {
+        state.selectedService = { id: serviceId, duration: duration, name: name };
+        console.log(`🔧 Chocovainilla Wizard: Servicio seleccionado ID ${serviceId}, Duración ${duration} min.`);
+        state.selectedSlot = null;
+        dom.confirmBtn.prop('disabled', true);
+
+        if (state.selectedDate) {
+            fetchAndRenderSlots(state.selectedDate);
+        } else {
+            updateSlotsMessage('Selecciona una fecha para ver los horarios disponibles.');
+        }
+    }
+
+    function updateSlotsMessage(message) {
+        if (dom.slotsWrapper && dom.slotsWrapper.length) {
+            dom.slotsWrapper.html(`<div class="slots-message">${message}</div>`);
+        }
+        if (dom.slotsPagination && dom.slotsPagination.length) {
+            dom.slotsPagination.empty();
+        }
+    }
+
+    function renderSlotsPagination(totalSlots) {
+        if (!dom.slotsPagination || !dom.slotsPagination.length) return;
+        dom.slotsPagination.empty();
+        if (!totalSlots || totalSlots <= 4) {
+            return;
+        }
+        const groups = Math.ceil(totalSlots / 4);
+        let dotsHtml = '';
+        for (let i = 0; i < groups; i++) {
+            dotsHtml += `<span class="dot ${i === 0 ? 'active' : ''}"></span>`;
+        }
+        dom.slotsPagination.html(dotsHtml);
     }
 
     function fetchAndRenderSlots(date) {
-        dom.slotsContainer.html('<p>Cargando horarios...</p>');
+        console.log('⏰ Chocovainilla Wizard: consultando horarios para', date, 'y servicio', state.selectedService.id);
+        updateSlotsMessage('Cargando horarios disponibles...');
         dom.confirmBtn.prop('disabled', true);
         state.selectedSlot = null;
-        
-        // Usamos la función de VAApi que ya existe
+
         VAApi.getAvailableSlots(state.professionalId, state.selectedService.id, date)
             .done(function(response) {
-                if (response.success && response.data.length > 0) {
-                    const slotsHtml = response.data.map(slot => `<button class="time-slot" data-time="${slot}">${slot}</button>`).join('');
-                    dom.slotsContainer.html(`<div class="time-slots">${slotsHtml}</div>`);
+                if (response.success && Array.isArray(response.data) && response.data.length > 0) {
+                    const slotsHtml = response.data.map(slot => `<button type="button" class="time-slot" data-time="${slot}">${slot}</button>`).join('');
+                    dom.slotsWrapper.html(slotsHtml);
+                    renderSlotsPagination(response.data.length);
                 } else {
-                    dom.slotsContainer.html('<p>No hay horarios disponibles para este día.</p>');
+                    updateSlotsMessage('No hay horarios disponibles para esta fecha.');
                 }
             })
             .fail(function() {
-                dom.slotsContainer.html('<p>Ocurrió un error al cargar los horarios.</p>');
+                updateSlotsMessage('Ocurrió un error al cargar los horarios.');
             });
     }
 
@@ -606,7 +658,7 @@ const AgendaWizard = (function ($) {
                     if (window.VA_AgendaModule && typeof window.VA_AgendaModule.reloadDataFromAJAX === 'function') {
                         window.VA_AgendaModule.reloadDataFromAJAX();
                     }
-                    dom.confirmBtn.prop('disabled', false).text('Confirmar Cita');
+                    dom.confirmBtn.prop('disabled', false).text('Confirmar cita');
                     return;
                     location.reload(); // Solución simple por ahora
                 } else {
@@ -616,7 +668,7 @@ const AgendaWizard = (function ($) {
             .fail(function(jqXHR) {
                 const msg = jqXHR?.responseJSON?.message || jqXHR?.responseText || 'Error desconocido al crear la cita';
                 alert('Error: ' + msg);
-                dom.confirmBtn.prop('disabled', false).text('Confirmar Cita');
+                dom.confirmBtn.prop('disabled', false).text('Confirmar cita');
             });
     }
     // <-- FIN DE NUEVAS FUNCIONES: Proyecto Chocovainilla - Paso 1.5/1.6 -->

--- a/templates/modules/agenda-module.php
+++ b/templates/modules/agenda-module.php
@@ -157,196 +157,250 @@ if (!empty($services)) {
         </div>
     </div>
 
-    <div id="appointment-modal" class="modal-overlay hidden">
-        <div class="modal-content">
-            <button type="button" class="modal-close-x" aria-label="Cerrar modal">&times;</button>
-            <h3 id="modal-title" class="modal-title">Detalles de la Cita</h3>
-            <div id="modal-details" class="modal-details"></div>
-            
-            <!-- SECCIÓN PARA CAMBIAR ESTADO -->
-            <div class="modal-section">
-                <p class="modal-section-title">Cambiar estado de la cita:</p>
-                <div id="status-buttons-container" class="status-buttons-grid">
-                    <!-- Los botones se generan dinámicamente aquí -->
+    <div id="appointment-modal" class="modal-overlay hidden agenda-modal">
+        <div class="modal-content modal-small appointment-modal">
+            <div class="modal-handle" aria-hidden="true"></div>
+            <header class="modal-header appointment-modal__header">
+                <div class="appointment-modal__title-group">
+                    <h3 id="modal-title" class="modal-title">Detalles de la Cita</h3>
+                    <div id="appointment-status-pill" class="status-pill" hidden>
+                        <span class="status-pill-indicator" aria-hidden="true"></span>
+                        <span id="appointment-status-label">Estado</span>
+                    </div>
                 </div>
-            </div>
-
-            
-        </div>
-    </div>
-
-    <!-- <-- INICIO DEL CAMBIO: Proyecto Chocovainilla - Paso 1.1 --> -->
-    <div id="agenda-booking-wizard-modal" class="modal-overlay hidden">
-        <div class="modal-content large">
-            <div class="modal-header">
-                <h3 id="wizard-title" class="modal-title">Agendar Nueva Cita</h3>
-                <button id="wizard-close-btn" class="modal-close-btn">
+                <button type="button" class="modal-close-btn" aria-label="Cerrar modal">
                     <i class="fas fa-times"></i>
                 </button>
+            </header>
+            <div class="modal-body appointment-modal__body">
+                <div id="modal-details" class="appointment-details-grid"></div>
             </div>
+            <footer class="modal-footer appointment-modal__footer">
+                <div id="status-buttons-container" class="status-actions"></div>
+            </footer>
+        </div>
+    </div>
 
-            <div id="wizard-body" class="modal-body">
-
-                <div class="wizard-step active" data-step="1">
-                    <h4 class="wizard-step-title">Paso 1: Identificar al Cliente</h4>
-                    <div class="form-group">
-                        <label for="wizard-client-search" class="form-label">Buscar cliente por nombre o email</label>
-                        <input type="text" id="wizard-client-search" class="form-input" placeholder="Comienza a escribir para buscar...">
-                    </div>
-                    <div id="wizard-search-results" class="search-results-container">
-                        <p class="text-center text-gray-500">Introduce al menos 3 caracteres para buscar.</p>
-                    </div>
-                    <div class="form-actions" style="justify-content: center; margin-top: 1rem;">
-                        <button id="wizard-new-client-btn" class="btn-secondary">
-                            <i class="fas fa-user-plus"></i> Registrar Cliente Nuevo
-                        </button>
-                    </div>
+    <div id="agenda-booking-wizard-modal" class="modal-overlay hidden agenda-modal">
+        <div class="modal-content modal-large agenda-wizard">
+            <div class="modal-handle" aria-hidden="true"></div>
+            <header class="modal-header wizard-header">
+                <div class="wizard-header__text">
+                    <h3 id="wizard-title" class="modal-title">Agendar Nueva Cita</h3>
+                    <p id="wizard-subtitle" class="modal-subtitle">Sigue los pasos para crear una cita en minutos.</p>
                 </div>
+                <button id="wizard-close-btn" class="modal-close-btn" aria-label="Cerrar modal">
+                    <i class="fas fa-times"></i>
+                </button>
+            </header>
 
-                <div class="wizard-step" data-step="1.5" style="display: none;">
-                    <h4 class="wizard-step-title">Paso 1.5: Registrar Cliente Nuevo</h4>
-                    <form id="wizard-client-form-inline">
-                        <div class="form-group">
-                            <label for="wizard-client-name-inline" class="form-label">Nombre del Cliente *</label>
-                            <input type="text" id="wizard-client-name-inline" name="client-name" class="form-input" required placeholder="Ej: Ana García Martínez">
-                        </div>
-                        <div class="form-group">
-                            <label for="wizard-client-email-inline" class="form-label">Correo Electrónico</label>
-                            <input type="email" id="wizard-client-email-inline" name="client-email" class="form-input" placeholder="ana.garcia@email.com">
-                            <small class="form-help">Se enviará una invitación automática si se proporciona email</small>
-                        </div>
-                        <div class="form-group">
-                            <label for="wizard-client-phone-inline" class="form-label">Teléfono</label>
-                            <div class="phone-input-group">
-                                <select id="wizard-client-phone-code-inline" name="client-phone-code" class="form-input phone-code-select">
-                                    <option value="+52">🇲🇽 +52 MX</option>
-                                    <option value="+1">🇺🇸 +1 US</option>
-                                    <option value="+1">🇨🇦 +1 CA</option>
-                                    <option value="+34">🇪🇸 +34 ES</option>
-                                    <option value="+44">🇬🇧 +44 UK</option>
-                                    <option value="+33">🇫🇷 +33 FR</option>
-                                    <option value="+49">🇩🇪 +49 DE</option>
-                                    <option value="+39">🇮🇹 +39 IT</option>
-                                    <option value="+7">🇷🇺 +7 RU</option>
-                                    <option value="+81">🇯🇵 +81 JP</option>
-                                    <option value="+86">🇨🇳 +86 CN</option>
-                                    <option value="+55">🇧🇷 +55 BR</option>
-                                    <option value="+54">🇦🇷 +54 AR</option>
-                                    <option value="+57">🇨🇴 +57 CO</option>
-                                    <option value="+56">🇨🇱 +56 CL</option>
-                                    <option value="+58">🇻🇪 +58 VE</option>
-                                    <option value="+503">🇸🇻 +503 SV</option>
-                                    <option value="+505">🇳🇮 +505 NI</option>
-                                    <option value="+506">🇨🇷 +506 CR</option>
-                                    <option value="+507">🇵🇦 +507 PA</option>
-                                    <option value="+502">🇬🇹 +502 GT</option>
-                                    <option value="+504">🇭🇳 +504 HN</option>
-                                </select>
-                                <input type="tel" id="wizard-client-phone-inline" name="client-phone" class="form-input phone-number-input" placeholder="Número local (ej: 555 123 4567)">
-                            </div>
-                            <small class="form-help">Selecciona la lada y escribe el número local</small>
-                        </div>
-                        <div class="form-actions">
-                            <button type="button" id="wizard-back-to-search-inline" class="btn-secondary">Volver a Búsqueda</button>
-                            <button type="submit" class="btn-primary" id="wizard-create-client-inline">Crear Cliente</button>
-                        </div>
-                    </form>
-                </div>
-
-                <div class="wizard-step" data-step="2" style="display: none;">
-                    <h4 class="wizard-step-title">Paso 2: Seleccionar Mascota</h4>
-                    <p>Cliente: <strong id="wizard-selected-client-name"></strong></p>
-                    <div id="wizard-pet-selection" class="pet-selection-container">
-                        </div>
-                    <div class="form-actions" style="margin-top: 1rem;">
-                        <button id="wizard-back-to-search-btn" class="btn-secondary">Volver a la Búsqueda</button>
-                        <button id="wizard-new-pet-btn" class="btn-primary">
-                            <i class="fas fa-plus"></i> Registrar Mascota Nueva
-                        </button>
+            <div id="wizard-body" class="modal-body wizard-body">
+                <nav class="progress-bar" aria-label="Progreso del asistente">
+                    <div class="progress-step active" data-progress-step="1">
+                        <div class="progress-step-number">1</div>
+                        <span class="progress-step-label">Cliente</span>
                     </div>
-                </div>
+                    <div class="progress-bar-divider" aria-hidden="true"></div>
+                    <div class="progress-step" data-progress-step="2">
+                        <div class="progress-step-number">2</div>
+                        <span class="progress-step-label">Mascota</span>
+                    </div>
+                    <div class="progress-bar-divider" aria-hidden="true"></div>
+                    <div class="progress-step" data-progress-step="3">
+                        <div class="progress-step-number">3</div>
+                        <span class="progress-step-label">Servicio y horario</span>
+                    </div>
+                </nav>
 
-                <div class="wizard-step" data-step="2.5" style="display: none;">
-                    <h4 class="wizard-step-title">Paso 2.5: Registrar Mascota Nueva</h4>
-                    <p>Cliente: <strong id="wizard-selected-client-name-pet"></strong></p>
-                    <form id="wizard-pet-form-inline">
-                        <div class="form-group">
-                            <label for="wizard-pet-name-inline" class="form-label">Nombre de la Mascota *</label>
-                            <input type="text" id="wizard-pet-name-inline" name="pet-name" class="form-input" required placeholder="Ej: Luna">
+                <div class="wizard-steps">
+                    <section class="wizard-step wizard-step-content active" data-step="1" aria-labelledby="wizard-step-1-title">
+                        <div class="wizard-step-header">
+                            <h4 id="wizard-step-1-title" class="wizard-step-title">Identificar al cliente</h4>
+                            <p class="wizard-step-subtitle">Busca un cliente existente o regístralo en el momento.</p>
                         </div>
-                        <div class="form-group">
-                            <label for="wizard-pet-species-inline" class="form-label">Especie *</label>
-                            <select id="wizard-pet-species-inline" name="pet-species" class="form-input" required>
-                                <option value="">Selecciona una especie</option>
-                                <option value="dog">Perro</option>
-                                <option value="cat">Gato</option>
-                                <option value="bird">Ave</option>
-                                <option value="rabbit">Conejo</option>
-                                <option value="other">Otro</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="wizard-pet-breed-inline" class="form-label">Raza</label>
-                            <input type="text" id="wizard-pet-breed-inline" name="pet-breed" class="form-input" placeholder="Ej: Labrador, Siamés, etc.">
-                        </div>
-                        <div class="form-group">
-                            <label for="wizard-pet-gender-inline" class="form-label">Género</label>
-                            <select id="wizard-pet-gender-inline" name="pet-gender" class="form-input">
-                                <option value="unknown">No especificar</option>
-                                <option value="male">Macho</option>
-                                <option value="female">Hembra</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="wizard-pet-share-code-inline" class="form-label">Share Code</label>
-                            <div class="input-group">
-                                <input type="text" id="wizard-pet-share-code-inline" name="pet-share-code" class="form-input" readonly placeholder="Se genera automáticamente">
-                                <button type="button" class="btn-secondary" id="wizard-regenerate-code-inline">🔄</button>
-                            </div>
-                            <small class="form-help">Este código se enviará al cliente por email para vincular su mascota</small>
-                        </div>
-                        <div class="form-actions">
-                            <button type="button" id="wizard-back-to-pets-inline" class="btn-secondary">Volver a Mascotas</button>
-                            <button type="submit" class="btn-primary" id="wizard-create-pet-inline">Crear Mascota</button>
-                        </div>
-                    </form>
-                </div>
-
-                <div class="wizard-step" data-step="3" style="display: none;">
-                    <h4 class="wizard-step-title">Paso 3: Seleccionar Servicio y Horario</h4>
-                    <p>Agendando para: <strong id="wizard-selected-pet-name"></strong></p>
-                    
-                                                    <div id="wizard-scheduling-interface" class="service-selection-layout">
-                                    <div class="category-tabs">
-                                    </div>
-                                    <div class="service-list-content">
-                                    </div>
-                                    <div class="time-selection-content" style="display: none;">
-                                        <div class="va-calendar-wrapper">
-                                            <div id="va-calendar-header"></div>
-                                            <div id="va-calendar-grid"></div>
-                                        </div>
-                                        <div id="va-slots-container" class="time-slots-wrapper">
-                                            <p class="initial-message">Selecciona una fecha para ver los horarios.</p>
-                                        </div>
-                                    </div>
+                        <div class="wizard-step-body">
+                            <div class="form-group">
+                                <label for="wizard-client-search" class="form-label">Buscar cliente por nombre o email</label>
+                                <div class="input-with-icon">
+                                    <i class="fas fa-search" aria-hidden="true"></i>
+                                    <input type="text" id="wizard-client-search" class="form-input" placeholder="Comienza a escribir para buscar...">
                                 </div>
+                            </div>
+                            <div id="wizard-search-results" class="search-results-card">
+                                <p class="search-placeholder">Introduce al menos 3 caracteres para buscar.</p>
+                            </div>
+                        </div>
+                        <div class="wizard-step-footer">
+                            <button id="wizard-new-client-btn" class="btn-secondary">
+                                <i class="fas fa-user-plus"></i> Registrar cliente nuevo
+                            </button>
+                        </div>
+                    </section>
 
-                    <div class="form-actions" style="margin-top: 1rem;">
-                        <button id="wizard-back-to-pets-btn" class="btn-secondary">Volver a Mascotas</button>
-                        <button id="wizard-confirm-appointment-btn" class="btn-primary" disabled>Confirmar Cita</button>
-                    </div>
+                    <section class="wizard-step wizard-step-content" data-step="1.5" aria-labelledby="wizard-step-1-5-title">
+                        <div class="wizard-step-header">
+                            <h4 id="wizard-step-1-5-title" class="wizard-step-title">Registrar cliente nuevo</h4>
+                            <p class="wizard-step-subtitle">Completa la información básica para crear el perfil.</p>
+                        </div>
+                        <form id="wizard-client-form-inline" class="wizard-form">
+                            <div class="form-group">
+                                <label for="wizard-client-name-inline" class="form-label">Nombre del cliente *</label>
+                                <input type="text" id="wizard-client-name-inline" name="client-name" class="form-input" required placeholder="Ej: Ana García Martínez">
+                            </div>
+                            <div class="form-group">
+                                <label for="wizard-client-email-inline" class="form-label">Correo electrónico</label>
+                                <input type="email" id="wizard-client-email-inline" name="client-email" class="form-input" placeholder="ana.garcia@email.com">
+                                <small class="form-help">Se enviará una invitación automática si se proporciona email.</small>
+                            </div>
+                            <div class="form-group">
+                                <label for="wizard-client-phone-inline" class="form-label">Teléfono</label>
+                                <div class="phone-input-group">
+                                    <select id="wizard-client-phone-code-inline" name="client-phone-code" class="form-input phone-code-select">
+                                        <option value="+52">🇲🇽 +52 MX</option>
+                                        <option value="+1">🇺🇸 +1 US</option>
+                                        <option value="+1">🇨🇦 +1 CA</option>
+                                        <option value="+34">🇪🇸 +34 ES</option>
+                                        <option value="+44">🇬🇧 +44 UK</option>
+                                        <option value="+33">🇫🇷 +33 FR</option>
+                                        <option value="+49">🇩🇪 +49 DE</option>
+                                        <option value="+39">🇮🇹 +39 IT</option>
+                                        <option value="+7">🇷🇺 +7 RU</option>
+                                        <option value="+81">🇯🇵 +81 JP</option>
+                                        <option value="+86">🇨🇳 +86 CN</option>
+                                        <option value="+55">🇧🇷 +55 BR</option>
+                                        <option value="+54">🇦🇷 +54 AR</option>
+                                        <option value="+57">🇨🇴 +57 CO</option>
+                                        <option value="+56">🇨🇱 +56 CL</option>
+                                        <option value="+58">🇻🇪 +58 VE</option>
+                                        <option value="+503">🇸🇻 +503 SV</option>
+                                        <option value="+505">🇳🇮 +505 NI</option>
+                                        <option value="+506">🇨🇷 +506 CR</option>
+                                        <option value="+507">🇵🇦 +507 PA</option>
+                                        <option value="+502">🇬🇹 +502 GT</option>
+                                        <option value="+504">🇭🇳 +504 HN</option>
+                                    </select>
+                                    <input type="tel" id="wizard-client-phone-inline" name="client-phone" class="form-input phone-number-input" placeholder="Número local (ej: 555 123 4567)">
+                                </div>
+                                <small class="form-help">Selecciona la lada y escribe el número local.</small>
+                            </div>
+                            <div class="wizard-step-footer">
+                                <button type="button" id="wizard-back-to-search-inline" class="btn-light">Volver a búsqueda</button>
+                                <button type="submit" class="btn-primary" id="wizard-create-client-inline">Crear cliente</button>
+                            </div>
+                        </form>
+                    </section>
+
+                    <section class="wizard-step wizard-step-content" data-step="2" aria-labelledby="wizard-step-2-title">
+                        <div class="wizard-step-header">
+                            <h4 id="wizard-step-2-title" class="wizard-step-title">Seleccionar mascota</h4>
+                            <p class="wizard-step-subtitle">Elige la mascota asociada a la cita o regístrala rápidamente.</p>
+                        </div>
+                        <div class="wizard-step-body">
+                            <div class="info-banner" id="wizard-selected-client-banner">
+                                Cliente seleccionado: <span id="wizard-selected-client-name"></span>
+                            </div>
+                            <div id="wizard-pet-selection" class="pet-selection-list"></div>
+                        </div>
+                        <div class="wizard-step-footer">
+                            <button id="wizard-back-to-search-btn" class="btn-light">Volver a búsqueda</button>
+                            <button id="wizard-new-pet-btn" class="btn-secondary">
+                                <i class="fas fa-plus"></i> Registrar mascota nueva
+                            </button>
+                        </div>
+                    </section>
+
+                    <section class="wizard-step wizard-step-content" data-step="2.5" aria-labelledby="wizard-step-2-5-title">
+                        <div class="wizard-step-header">
+                            <h4 id="wizard-step-2-5-title" class="wizard-step-title">Registrar mascota nueva</h4>
+                            <p class="wizard-step-subtitle">Añade los datos básicos para crear la ficha de la mascota.</p>
+                        </div>
+                        <form id="wizard-pet-form-inline" class="wizard-form">
+                            <p class="wizard-form-intro">Cliente: <strong id="wizard-selected-client-name-pet"></strong></p>
+                            <div class="form-group">
+                                <label for="wizard-pet-name-inline" class="form-label">Nombre de la mascota *</label>
+                                <input type="text" id="wizard-pet-name-inline" name="pet-name" class="form-input" required placeholder="Ej: Luna">
+                            </div>
+                            <div class="form-group">
+                                <label for="wizard-pet-species-inline" class="form-label">Especie *</label>
+                                <select id="wizard-pet-species-inline" name="pet-species" class="form-input" required>
+                                    <option value="">Selecciona una especie</option>
+                                    <option value="dog">Perro</option>
+                                    <option value="cat">Gato</option>
+                                    <option value="bird">Ave</option>
+                                    <option value="rabbit">Conejo</option>
+                                    <option value="other">Otro</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="wizard-pet-breed-inline" class="form-label">Raza</label>
+                                <input type="text" id="wizard-pet-breed-inline" name="pet-breed" class="form-input" placeholder="Ej: Labrador, Siamés, etc.">
+                            </div>
+                            <div class="form-group">
+                                <label for="wizard-pet-gender-inline" class="form-label">Género</label>
+                                <select id="wizard-pet-gender-inline" name="pet-gender" class="form-input">
+                                    <option value="unknown">No especificar</option>
+                                    <option value="male">Macho</option>
+                                    <option value="female">Hembra</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="wizard-pet-share-code-inline" class="form-label">Share code</label>
+                                <div class="input-group">
+                                    <input type="text" id="wizard-pet-share-code-inline" name="pet-share-code" class="form-input" readonly placeholder="Se genera automáticamente">
+                                    <button type="button" class="btn-light" id="wizard-regenerate-code-inline" aria-label="Generar nuevo share code">🔄</button>
+                                </div>
+                                <small class="form-help">Este código se enviará al cliente para vincular la mascota.</small>
+                            </div>
+                            <div class="wizard-step-footer">
+                                <button type="button" id="wizard-back-to-pets-inline" class="btn-light">Volver a mascotas</button>
+                                <button type="submit" class="btn-primary" id="wizard-create-pet-inline">Crear mascota</button>
+                            </div>
+                        </form>
+                    </section>
+
+                    <section class="wizard-step wizard-step-content" data-step="3" aria-labelledby="wizard-step-3-title">
+                        <div class="wizard-step-header">
+                            <h4 id="wizard-step-3-title" class="wizard-step-title">Servicio y horario</h4>
+                            <p id="wizard-selected-pet-name" class="wizard-step-subtitle"></p>
+                        </div>
+                        <div class="wizard-step-body">
+                            <div class="wizard-grid">
+                                <div class="form-group">
+                                    <label class="form-label" for="wiz-category">Categoría</label>
+                                    <select id="wiz-category" class="form-input">
+                                        <option value="">Selecciona una categoría</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="wiz-service">Servicio</label>
+                                    <select id="wiz-service" class="form-input" disabled>
+                                        <option value="">Selecciona una categoría primero</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="wiz-date">Fecha</label>
+                                    <input type="date" id="wiz-date" class="form-input">
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label" for="wiz-slots">Horarios disponibles</label>
+                                <div id="wiz-slots-container" class="slot-picker">
+                                    <div id="wiz-slots-wrapper" class="slot-list">
+                                        <div id="wiz-slots" class="slots-message">Selecciona un servicio para ver los horarios disponibles.</div>
+                                    </div>
+                                    <div id="wiz-slots-pagination" class="slot-pagination" aria-hidden="true"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="wizard-step-footer">
+                            <button id="wizard-back-to-pets-btn" class="btn-light">Volver a mascotas</button>
+                            <button id="wizard-confirm-appointment-btn" class="btn-primary" disabled>Confirmar cita</button>
+                        </div>
+                    </section>
                 </div>
-
             </div>
         </div>
-        <script>
-            // Mensaje de depuración para verificar la carga del nuevo HTML
-            console.log("✅ Chocovainilla: Nuevo HTML del Wizard de Agendamiento cargado en el DOM.");
-        </script>
     </div>
-    <!-- <-- FIN DEL CAMBIO: Proyecto Chocovainilla - Paso 1.1 --> -->
-
     <!-- El modal de la bitácora ha sido eliminado. La funcionalidad ahora está integrada en #appointment-modal -->
 </div>
 


### PR DESCRIPTION
## Summary
- replace the appointment detail modal markup with the mockup structure including the status pill and info cards
- rebuild the agenda wizard markup and styles to incorporate the progress bar, responsive layout, and slot carousel
- update the agenda JS controllers to populate the new DOM structure and drive the category/service/date slot selection flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de32f08f208327a380c4e5d559321a